### PR TITLE
Add a simple spotify monitor

### DIFF
--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,0 +1,2 @@
+class Song < ApplicationRecord
+end

--- a/bin/monitor
+++ b/bin/monitor
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require_relative '../config/environment'
+
+logger = Logger.new(STDOUT)
+logger.info "Starting monitor"
+s = Spotify::Monitor.new
+s.logger = logger
+
+s.on_started do |song_data|
+  puts "start: #{song_data[:name]} - #{song_data[:artist]} - #{song_data[:album]}"
+end
+
+s.on_playing do |song_data|
+  puts "playing: #{song_data[:name]} - #{song_data[:artist]} - #{song_data[:album]}"
+end
+
+s.on_ending do |song_data|
+  puts "ending: #{song_data[:name]} - #{song_data[:artist]} - #{song_data[:album]}"
+end
+
+s.start_listening!

--- a/db/migrate/20160125090513_create_songs.rb
+++ b/db/migrate/20160125090513_create_songs.rb
@@ -1,0 +1,15 @@
+class CreateSongs < ActiveRecord::Migration[5.0]
+  def change
+    create_table :songs do |t|
+      t.string :name
+      t.string :artist
+      t.string :album
+      t.datetime :last_played_at
+      t.integer :duration
+      t.string :artwork
+      t.string :external_id
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/spotify.rb
+++ b/lib/spotify.rb
@@ -1,1 +1,2 @@
 require_relative "./spotify/player.rb"
+require_relative "./spotify/monitor"

--- a/lib/spotify/monitor.rb
+++ b/lib/spotify/monitor.rb
@@ -1,0 +1,105 @@
+module Spotify
+  class Sample
+    STARTING = "starting"
+    PLAYING = "playing"
+    ENDING = "ending"
+
+    attr_accessor :data
+
+    def initialize(sample_data)
+      @data = sample_data
+    end
+
+    def state
+      return "#{STARTING}-#{data[:id]}" if starting?
+      return "#{ENDING}-#{data[:id]}" if ending?
+      "#{PLAYING}-#{data[:id]}"
+    end
+
+    def starting?
+      data[:position] < 10
+    end
+
+    def playing?
+      !starting? && !ending?
+    end
+
+    def ending?
+      remaining = data[:duration] - data[:position]
+      remaining < 10
+    end
+
+  end
+
+  class Monitor
+
+    attr_accessor :interval
+    attr_accessor :running
+    attr_accessor :state
+    attr_accessor :logger
+
+    def initialize(*)
+      @interval = 1
+      @running = false
+    end
+
+    def stop_listening!
+      @running = false
+    end
+
+    def start_listening!
+      self.running = true
+      listen
+    end
+
+    def listen
+      while running
+        poll_spotify
+        sleep interval
+      end
+    end
+
+    def poll_spotify
+      sample = Sample.new player.now_playing
+      process_reading(sample) if sample.state != state
+    rescue StandardError => e
+      logger.error(e)
+      # Swallow, because we want to keep listening
+    end
+
+    def process_reading(sample)
+      self.state = sample.state
+      logger.info state
+      on_started.call(sample.data) if sample.starting?
+      on_playing.call(sample.data) if sample.playing?
+      on_ending.call(sample.data) if sample.ending?
+    end
+
+    def on_started
+      @on_started ||= proc {}
+      @on_started = proc { |song_data| yield(song_data) } if block_given?
+      @on_started
+    end
+
+    def on_playing
+      @on_playing ||= proc {}
+      @on_playing = proc { |song_data| yield(song_data) } if block_given?
+      @on_playing
+    end
+
+    def on_ending
+      @on_ending ||= proc {}
+      @on_ending = proc { |song_data| yield(song_data) } if block_given?
+      @on_ending
+    end
+
+    def player
+      Ffwd::Spotify::Player
+    end
+
+    def logger
+      @logger ||= Rails.logger
+    end
+
+  end
+end

--- a/test/fixtures/songs.yml
+++ b/test/fixtures/songs.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  artist: MyString
+  album: MyString
+  last_played_at: 2016-01-25 10:05:13
+  duration: 1
+  artwork: MyString
+  external_id: MyString
+
+two:
+  name: MyString
+  artist: MyString
+  album: MyString
+  last_played_at: 2016-01-25 10:05:13
+  duration: 1
+  artwork: MyString
+  external_id: MyString

--- a/test/models/song_test.rb
+++ b/test/models/song_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SongTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
The monitor will poll Spotify using Applescript every second.

The monitor considers 3 states:
- Started: The first 10 seconds of a song
- Ending: The last 10 seconds of a song
- Playing: Everywhere in between

You can specify what to do when the state changes by providing a block:
A basic example of this in `bin/monitor`
